### PR TITLE
Fixes issue #3: fix(sockets): reuse dead slots in SocketsInner::register

### DIFF
--- a/crates/tokio-wireguard/src/interface/sockets.rs
+++ b/crates/tokio-wireguard/src/interface/sockets.rs
@@ -63,8 +63,8 @@ impl<T> SocketsInner<T> {
     fn register(&mut self, socket: crate::Shared<T>) {
         let slot = self.sockets.iter_mut().enumerate().find_map(|(i, s)| {
             match Arc::get_mut(s).map(Mutex::get_mut) {
-                Some(..) => None,
-                None => Some(i),
+                Some(..) => Some(i),
+                None => None,  
             }
         });
 


### PR DESCRIPTION
Arc::get_mut returns Some when strong_count == 1 (no live clones, slot is dead) and None when strong_count >= 2 (a TcpStream still holds the Arc, slot is active). The match arms were inverted, so register() would overwrite active socket slots instead of reusing dead ones.

This removed active sockets from the sockets Vec while live TcpStreams still held Arc clones of them. The smoltcp event loop stopped seeing those sockets, causing all concurrent TCP connections except the last one to hang indefinitely on reads and writes.